### PR TITLE
Add categorize & relate result visualizer

### DIFF
--- a/pipelines/categorize_and_relate/ui/sample_output.json
+++ b/pipelines/categorize_and_relate/ui/sample_output.json
@@ -1,0 +1,66 @@
+{
+  "result": {
+    "segments": [
+      {
+        "id": "C1",
+        "category": "Planning",
+        "summary": "This segment introduces the subject – ‘you’ – representing the initial focus and scope of a potential project or discussion.",
+        "confidence": 0.95,
+        "connections": [],
+        "text_ranges": [
+          {
+            "start_char": 0,
+            "end_char": 3,
+            "excerpt": "you",
+            "relevance": 1,
+            "actual_text": "you"
+          }
+        ]
+      },
+      {
+        "id": "C2",
+        "category": "Inquiry",
+        "summary": "A follow up question regarding the main topic.",
+        "confidence": 0.87,
+        "connections": [],
+        "text_ranges": [
+          {
+            "start_char": 4,
+            "end_char": 8,
+            "excerpt": "what",
+            "relevance": 1,
+            "actual_text": "what"
+          }
+        ]
+      }
+    ],
+    "connections_summary": [],
+    "open_topics": [
+      {
+        "topic": "Purpose of 'you'",
+        "question": "What is the intended meaning or role of 'you' in this context?",
+        "related_segments": ["C1"],
+        "status": "Unanswered"
+      }
+    ]
+  },
+  "metadata": {
+    "session_id": "20250828_190327_41908882",
+    "timestamp": "2025-08-28T19:03:27.106764",
+    "audio_file": "audio.webm",
+    "transcript": "you what",
+    "artifacts": ["audio.webm", "transcript", "categorization"],
+    "processing_steps": 6,
+    "session_summary": {
+      "session_id": "20250828_190327_41908882",
+      "status": "completed",
+      "created": "2025-08-28T19:03:27.106764",
+      "last_updated": "2025-08-28T19:03:55.195741",
+      "artifact_count": 3,
+      "artifacts": ["audio.webm", "transcript", "categorization"],
+      "processing_steps": 6,
+      "errors": 0,
+      "directory_size": 52315
+    }
+  }
+}

--- a/pipelines/categorize_and_relate/ui/visualizer.html
+++ b/pipelines/categorize_and_relate/ui/visualizer.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Categorize & Relate Visualizer</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #transcript span { line-height: 1.6; }
+    pre { background: #f4f4f4; padding: 10px; border: 1px solid #ccc; overflow: auto; }
+    input[type=file] { margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Categorize & Relate Result Viewer</h1>
+  <input type="file" id="fileInput" accept="application/json" />
+  <h2>Transcript</h2>
+  <div id="transcript"></div>
+  <h2>Raw JSON</h2>
+  <pre id="json"></pre>
+
+  <script type="module">
+    import { loadData } from './visualizer.js';
+
+    const input = document.getElementById('fileInput');
+    input.addEventListener('change', (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        const data = JSON.parse(ev.target.result);
+        loadData(data);
+      };
+      reader.readAsText(file);
+    });
+  </script>
+</body>
+</html>

--- a/pipelines/categorize_and_relate/ui/visualizer.js
+++ b/pipelines/categorize_and_relate/ui/visualizer.js
@@ -1,0 +1,62 @@
+const topicColors = {};
+const colorPalette = [
+  '#e6194b', '#3cb44b', '#ffe119', '#0082c8', '#f58231',
+  '#911eb4', '#46f0f0', '#f032e6', '#d2f53c', '#fabebe',
+  '#008080', '#e6beff', '#aa6e28', '#fffac8', '#800000',
+  '#aaffc3', '#808000', '#ffd8b1', '#000080', '#808080'
+];
+
+function assignColor(topic) {
+  if (!topicColors[topic]) {
+    const idx = Object.keys(topicColors).length % colorPalette.length;
+    topicColors[topic] = colorPalette[idx];
+  }
+  return topicColors[topic];
+}
+
+function renderTranscript(text, segments) {
+  const ranges = [];
+  segments.forEach(seg => {
+    const color = assignColor(seg.category || seg.topic || 'unknown');
+    (seg.text_ranges || []).forEach(r => {
+      if (typeof r.start_char === 'number' && typeof r.end_char === 'number') {
+        ranges.push({ start: r.start_char, end: r.end_char, color });
+      }
+    });
+  });
+  ranges.sort((a, b) => a.start - b.start);
+
+  const container = document.getElementById('transcript');
+  container.innerHTML = '';
+
+  let cursor = 0;
+  ranges.forEach(r => {
+    if (cursor < r.start) {
+      const span = document.createElement('span');
+      span.textContent = text.slice(cursor, r.start);
+      container.appendChild(span);
+    }
+    const span = document.createElement('span');
+    span.textContent = text.slice(r.start, r.end);
+    span.style.borderBottom = `4px solid ${r.color}`;
+    span.style.paddingBottom = '2px';
+    container.appendChild(span);
+    cursor = r.end;
+  });
+  if (cursor < text.length) {
+    const span = document.createElement('span');
+    span.textContent = text.slice(cursor);
+    container.appendChild(span);
+  }
+}
+
+function loadData(data) {
+  const jsonEl = document.getElementById('json');
+  jsonEl.textContent = JSON.stringify(data, null, 2);
+
+  const transcript = data.metadata?.transcript || '';
+  const segments = data.result?.segments || [];
+  renderTranscript(transcript, segments);
+}
+
+export { loadData };

--- a/pipelines/categorize_and_relate/ui/visualizer_test.html
+++ b/pipelines/categorize_and_relate/ui/visualizer_test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Categorize & Relate Visualizer Test</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #transcript span { line-height: 1.6; }
+    pre { background: #f4f4f4; padding: 10px; border: 1px solid #ccc; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>Visualizer Test Page</h1>
+  <h2>Transcript</h2>
+  <div id="transcript"></div>
+  <h2>Raw JSON</h2>
+  <pre id="json"></pre>
+
+  <script type="module">
+    import { loadData } from './visualizer.js';
+
+    fetch('./sample_output.json')
+      .then(resp => resp.json())
+      .then(data => loadData(data));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add browser page to load categorize & relate JSON and highlight transcript segments
- color-code topics and underline text by topic
- include static test page with sample output data

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd ui && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b08004148083298425a7166471e5ea